### PR TITLE
Fix for CMake optimization antipatterns

### DIFF
--- a/htslibConfig.cmake
+++ b/htslibConfig.cmake
@@ -36,7 +36,7 @@ endif()
 
 # shared CXX flags for src & tests
 include(CheckCXXCompilerFlag)
-set(htslib_CXX_FLAGS "-std=c++11 -Wall -Wextra -O3")
+set(htslib_CXX_FLAGS "-std=c++11 -Wall -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${htslib_CXX_FLAGS}")
 
 string(REGEX REPLACE "/libz.*" "" ZLIB_LIBRARY_REPLACED ${ZLIB_LIBRARIES})


### PR DESCRIPTION
Don't add -O3 to global compile flags, breaks debug builds.